### PR TITLE
 we had a supportrequest from Nordigen/goCardless to change the base …

### DIFF
--- a/src/RobinTTY.NordigenApiClient/Endpoints/AccountsEndpoint.cs
+++ b/src/RobinTTY.NordigenApiClient/Endpoints/AccountsEndpoint.cs
@@ -31,7 +31,7 @@ public class AccountsEndpoint : IAccountsEndpoint
         CancellationToken cancellationToken)
     {
         return await _nordigenClient.MakeRequest<BankAccount, BasicError>(
-            $"{NordigenEndpointUrls.AccountsEndpoint}{id}/", HttpMethod.Get, cancellationToken);
+            $"{NordigenEndpointUrls.AccountsEndpoint(_nordigenClient.BaseUrl)}{id}/", HttpMethod.Get, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -48,7 +48,7 @@ public class AccountsEndpoint : IAccountsEndpoint
         CancellationToken cancellationToken)
     {
         var response = await _nordigenClient.MakeRequest<BalanceJsonWrapper, AccountsError>(
-            $"{NordigenEndpointUrls.AccountsEndpoint}{accountId}/balances/", HttpMethod.Get, cancellationToken);
+            $"{NordigenEndpointUrls.AccountsEndpoint(_nordigenClient.BaseUrl)}{accountId}/balances/", HttpMethod.Get, cancellationToken);
         return new NordigenApiResponse<List<Balance>, AccountsError>(response.StatusCode, response.IsSuccess,
             response.Result?.Balances, response.Error);
     }
@@ -67,7 +67,7 @@ public class AccountsEndpoint : IAccountsEndpoint
         CancellationToken cancellationToken)
     {
         var response = await _nordigenClient.MakeRequest<BankAccountDetailsWrapper, AccountsError>(
-            $"{NordigenEndpointUrls.AccountsEndpoint}{id}/details/", HttpMethod.Get, cancellationToken);
+            $"{NordigenEndpointUrls.AccountsEndpoint(_nordigenClient.BaseUrl)}{id}/details/", HttpMethod.Get, cancellationToken);
         return new NordigenApiResponse<BankAccountDetails, AccountsError>(response.StatusCode, response.IsSuccess,
             response.Result?.Account, response.Error);
     }
@@ -109,7 +109,7 @@ public class AccountsEndpoint : IAccountsEndpoint
             query.Add(new KeyValuePair<string, string>("date_to", DateToIso8601(endDate.Value)));
 
         var response = await _nordigenClient.MakeRequest<AccountTransactionsWrapper, AccountsError>(
-            $"{NordigenEndpointUrls.AccountsEndpoint}{id}/transactions/", HttpMethod.Get, cancellationToken, query);
+            $"{NordigenEndpointUrls.AccountsEndpoint(_nordigenClient.BaseUrl)}{id}/transactions/", HttpMethod.Get, cancellationToken, query);
         return new NordigenApiResponse<AccountTransactions, AccountsError>(response.StatusCode, response.IsSuccess,
             response.Result?.Transactions, response.Error);
     }

--- a/src/RobinTTY.NordigenApiClient/Endpoints/AgreementsEndpoint.cs
+++ b/src/RobinTTY.NordigenApiClient/Endpoints/AgreementsEndpoint.cs
@@ -24,7 +24,7 @@ public class AgreementsEndpoint : IAgreementsEndpoint
         var query = new KeyValuePair<string, string>[]
             {new("limit", limit.ToString()), new("offset", offset.ToString())};
         return await _nordigenClient.MakeRequest<ResponsePage<Agreement>, BasicError>(
-            NordigenEndpointUrls.AgreementsEndpoint, HttpMethod.Get, cancellationToken, query);
+            NordigenEndpointUrls.AgreementsEndpoint(_nordigenClient.BaseUrl), HttpMethod.Get, cancellationToken, query);
     }
 
     /// <inheritdoc />
@@ -40,7 +40,7 @@ public class AgreementsEndpoint : IAgreementsEndpoint
     private async Task<NordigenApiResponse<Agreement, BasicError>> GetAgreementInternal(string id,
         CancellationToken cancellationToken) =>
         await _nordigenClient.MakeRequest<Agreement, BasicError>(
-            $"{NordigenEndpointUrls.AgreementsEndpoint}{id}/", HttpMethod.Get, cancellationToken);
+            $"{NordigenEndpointUrls.AgreementsEndpoint(_nordigenClient.BaseUrl)}{id}/", HttpMethod.Get, cancellationToken);
 
     /// <inheritdoc />
     public async Task<NordigenApiResponse<Agreement, CreateAgreementError>> CreateAgreement(
@@ -48,7 +48,7 @@ public class AgreementsEndpoint : IAgreementsEndpoint
     {
         var body = JsonContent.Create(agreement);
         return await _nordigenClient.MakeRequest<Agreement, CreateAgreementError>(
-            NordigenEndpointUrls.AgreementsEndpoint, HttpMethod.Post, cancellationToken, body: body);
+            NordigenEndpointUrls.AgreementsEndpoint(_nordigenClient.BaseUrl), HttpMethod.Post, cancellationToken, body: body);
     }
 
     /// <inheritdoc />
@@ -65,7 +65,7 @@ public class AgreementsEndpoint : IAgreementsEndpoint
         CancellationToken cancellationToken)
     {
         return await _nordigenClient.MakeRequest<BasicResponse, BasicError>(
-            $"{NordigenEndpointUrls.AgreementsEndpoint}{id}/", HttpMethod.Delete, cancellationToken);
+            $"{NordigenEndpointUrls.AgreementsEndpoint(_nordigenClient.BaseUrl)}{id}/", HttpMethod.Delete, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -83,6 +83,6 @@ public class AgreementsEndpoint : IAgreementsEndpoint
     {
         var body = JsonContent.Create(metadata);
         return await _nordigenClient.MakeRequest<Agreement, BasicError>(
-            $"{NordigenEndpointUrls.AgreementsEndpoint}{id}/accept/", HttpMethod.Put, cancellationToken, body: body);
+            $"{NordigenEndpointUrls.AgreementsEndpoint(_nordigenClient.BaseUrl)}{id}/accept/", HttpMethod.Put, cancellationToken, body: body);
     }
 }

--- a/src/RobinTTY.NordigenApiClient/Endpoints/InstitutionsEndpoint.cs
+++ b/src/RobinTTY.NordigenApiClient/Endpoints/InstitutionsEndpoint.cs
@@ -49,7 +49,7 @@ public class InstitutionsEndpoint : IInstitutionsEndpoint
         if (ssnVerificationSupported.HasValue)
             query.Add(GetSupportFlagQuery("ssn_verification_supported", ssnVerificationSupported.Value));
         return await _nordigenClient.MakeRequest<List<Institution>, InstitutionsError>(
-            NordigenEndpointUrls.InstitutionsEndpoint, HttpMethod.Get, cancellationToken, query);
+            NordigenEndpointUrls.InstitutionsEndpoint(_nordigenClient.BaseUrl), HttpMethod.Get, cancellationToken, query);
     }
 
     private static KeyValuePair<string, string> GetSupportFlagQuery(string flag, bool value)
@@ -59,5 +59,5 @@ public class InstitutionsEndpoint : IInstitutionsEndpoint
     public async Task<NordigenApiResponse<Institution, BasicError>> GetInstitution(string id,
         CancellationToken cancellationToken = default) =>
         await _nordigenClient.MakeRequest<Institution, BasicError>(
-            $"{NordigenEndpointUrls.InstitutionsEndpoint}{id}/", HttpMethod.Get, cancellationToken);
+            $"{NordigenEndpointUrls.InstitutionsEndpoint(_nordigenClient.BaseUrl)}{id}/", HttpMethod.Get, cancellationToken);
 }

--- a/src/RobinTTY.NordigenApiClient/Endpoints/NordigenEndpointUrls.cs
+++ b/src/RobinTTY.NordigenApiClient/Endpoints/NordigenEndpointUrls.cs
@@ -2,10 +2,30 @@
 
 internal static class NordigenEndpointUrls
 {
-    private const string Base = "https://bankaccountdata.gocardless.com/api/v2/";
-    internal const string TokensEndpoint = Base + "token/";
-    internal const string AccountsEndpoint = Base + "accounts/";
-    internal const string AgreementsEndpoint = Base + "agreements/enduser/";
-    internal const string InstitutionsEndpoint = Base + "institutions/";
-    internal const string RequisitionsEndpoint = Base + "requisitions/";
+    private const string DefaultBase = "https://bankaccountdata.gocardless.com/api/v2/";
+
+    internal static string TokensEndpoint(string? baseUrl = null)
+    {
+        return (baseUrl ?? DefaultBase) + "token/";
+    }
+
+    internal static string AccountsEndpoint(string? baseUrl = null)
+    {
+        return (baseUrl ?? DefaultBase) + "accounts/";
+    }
+
+    internal static string AgreementsEndpoint(string? baseUrl = null)
+    {
+        return (baseUrl ?? DefaultBase) + "agreements/enduser/";
+    }
+
+    internal static string InstitutionsEndpoint(string? baseUrl = null)
+    {
+        return (baseUrl ?? DefaultBase) + "institutions/";
+    }
+
+    internal static string RequisitionsEndpoint(string? baseUrl = null)
+    {
+        return (baseUrl ?? DefaultBase) + "requisitions/";
+    }
 }

--- a/src/RobinTTY.NordigenApiClient/Endpoints/RequisitionsEndpoint.cs
+++ b/src/RobinTTY.NordigenApiClient/Endpoints/RequisitionsEndpoint.cs
@@ -24,7 +24,7 @@ public class RequisitionsEndpoint : IRequisitionsEndpoint
         var query = new KeyValuePair<string, string>[]
             {new("limit", limit.ToString()), new("offset", offset.ToString())};
         return await _nordigenClient.MakeRequest<ResponsePage<Requisition>, BasicError>(
-            NordigenEndpointUrls.RequisitionsEndpoint, HttpMethod.Get, cancellationToken, query);
+            NordigenEndpointUrls.RequisitionsEndpoint(_nordigenClient.BaseUrl), HttpMethod.Get, cancellationToken, query);
     }
 
     /// <inheritdoc />
@@ -40,7 +40,7 @@ public class RequisitionsEndpoint : IRequisitionsEndpoint
     private async Task<NordigenApiResponse<Requisition, BasicError>> GetRequisitionInternal(string id,
         CancellationToken cancellationToken = default) =>
         await _nordigenClient.MakeRequest<Requisition, BasicError>(
-            $"{NordigenEndpointUrls.RequisitionsEndpoint}{id}/", HttpMethod.Get, cancellationToken);
+            $"{NordigenEndpointUrls.RequisitionsEndpoint(_nordigenClient.BaseUrl)}{id}/", HttpMethod.Get, cancellationToken);
 
     /// <inheritdoc />
     public async Task<NordigenApiResponse<Requisition, CreateRequisitionError>> CreateRequisition(
@@ -48,7 +48,7 @@ public class RequisitionsEndpoint : IRequisitionsEndpoint
     {
         var body = JsonContent.Create(requisition);
         return await _nordigenClient.MakeRequest<Requisition, CreateRequisitionError>(
-            NordigenEndpointUrls.RequisitionsEndpoint, HttpMethod.Post, cancellationToken, body: body);
+            NordigenEndpointUrls.RequisitionsEndpoint(_nordigenClient.BaseUrl), HttpMethod.Post, cancellationToken, body: body);
     }
 
     /// <inheritdoc />
@@ -64,5 +64,5 @@ public class RequisitionsEndpoint : IRequisitionsEndpoint
     private async Task<NordigenApiResponse<BasicResponse, BasicError>> DeleteRequisitionInternal(string id,
         CancellationToken cancellationToken) =>
         await _nordigenClient.MakeRequest<BasicResponse, BasicError>(
-            $"{NordigenEndpointUrls.RequisitionsEndpoint}{id}/", HttpMethod.Delete, cancellationToken);
+            $"{NordigenEndpointUrls.RequisitionsEndpoint(_nordigenClient.BaseUrl)}{id}/", HttpMethod.Delete, cancellationToken);
 }

--- a/src/RobinTTY.NordigenApiClient/Endpoints/TokenEndpoint.cs
+++ b/src/RobinTTY.NordigenApiClient/Endpoints/TokenEndpoint.cs
@@ -24,7 +24,7 @@ public class TokenEndpoint : ITokenEndpoint
     {
         var requestBody = JsonContent.Create(_nordigenClient.Credentials);
         return await _nordigenClient.MakeRequest<JsonWebTokenPair, BasicError>(
-            $"{NordigenEndpointUrls.TokensEndpoint}new/", HttpMethod.Post, cancellationToken, body: requestBody,
+            $"{NordigenEndpointUrls.TokensEndpoint(_nordigenClient.BaseUrl)}new/", HttpMethod.Post, cancellationToken, body: requestBody,
             useAuthentication: false);
     }
 
@@ -34,7 +34,7 @@ public class TokenEndpoint : ITokenEndpoint
     {
         var requestBody = JsonContent.Create(new {refresh = refreshToken.EncodedToken});
         return await _nordigenClient.MakeRequest<JsonWebAccessToken, BasicError>(
-            $"{NordigenEndpointUrls.TokensEndpoint}refresh/", HttpMethod.Post, cancellationToken, body: requestBody,
+            $"{NordigenEndpointUrls.TokensEndpoint(_nordigenClient.BaseUrl)}refresh/", HttpMethod.Post, cancellationToken, body: requestBody,
             useAuthentication: false);
     }
 }

--- a/src/RobinTTY.NordigenApiClient/NordigenClient.cs
+++ b/src/RobinTTY.NordigenApiClient/NordigenClient.cs
@@ -16,6 +16,7 @@ public class NordigenClient : INordigenClient
     private readonly HttpClient _httpClient;
     private readonly JsonSerializerOptions _serializerOptions;
     internal readonly NordigenClientCredentials Credentials;
+    internal readonly string? BaseUrl;
 
     /// <inheritdoc />
     public JsonWebTokenPair? JsonWebTokenPair { get; set; }
@@ -45,7 +46,7 @@ public class NordigenClient : INordigenClient
     /// <param name="credentials">The Nordigen credentials for API access.</param>
     /// <param name="jsonWebTokenPair">An optional JSON web token pair consisting of access and refresh token to use.</param>
     public NordigenClient(HttpClient httpClient, NordigenClientCredentials credentials,
-        JsonWebTokenPair? jsonWebTokenPair = null)
+        JsonWebTokenPair? jsonWebTokenPair = null, string? baseUrl = null)
     {
         _httpClient = httpClient;
         _serializerOptions = new JsonSerializerOptions
@@ -64,6 +65,7 @@ public class NordigenClient : INordigenClient
         AgreementsEndpoint = new AgreementsEndpoint(this);
         RequisitionsEndpoint = new RequisitionsEndpoint(this);
         AccountsEndpoint = new AccountsEndpoint(this);
+        BaseUrl = baseUrl;
     }
 
     internal async Task<NordigenApiResponse<TResponse, TError>> MakeRequest<TResponse, TError>(


### PR DESCRIPTION
…url from https://bankaccountdata.gocardless.com/api/v2/ to

"https://ob.gocardless.com/api/v2/" with this change we can set the default url.

I did not want to use HttpClient baseurl I guess it break everything if I use it.