### PR TITLE
Fix for Issue with ownerAddressUnstructured in BankAccountDetails model

### DIFF
--- a/src/RobinTTY.NordigenApiClient/Models/Responses/BankAccountDetails.cs
+++ b/src/RobinTTY.NordigenApiClient/Models/Responses/BankAccountDetails.cs
@@ -150,7 +150,7 @@ public class BankAccountDetails
     /// </param>
     [JsonConstructor]
     public BankAccountDetails(string resourceId, string iban, string? bic, string? bban, string currency,
-        string ownerName, string[]? ownerAddressUnstructured, string name, string product,
+        string ownerName, List<string>? ownerAddressUnstructured, string name, string product,
         CashAccountType? cashAccountType, string? details, string? linkedAccounts, string? msisdn,
         IsoBankAccountStatus? status, BankAccountUsage? usage, string? maskedPan)
     {

--- a/src/RobinTTY.NordigenApiClient/Models/Responses/BankAccountDetails.cs
+++ b/src/RobinTTY.NordigenApiClient/Models/Responses/BankAccountDetails.cs
@@ -56,7 +56,7 @@ public class BankAccountDetails
     /// Address of the legal account owner.
     /// </summary>
     [JsonPropertyName("ownerAddressUnstructured")]
-    public string? OwnerAddressUnstructured { get; }
+    public string[]? OwnerAddressUnstructured { get; }
 
     /// <summary>
     /// Name of the account, as assigned by the bank, in agreement with the account owner in
@@ -150,7 +150,7 @@ public class BankAccountDetails
     /// </param>
     [JsonConstructor]
     public BankAccountDetails(string resourceId, string iban, string? bic, string? bban, string currency,
-        string ownerName, string? ownerAddressUnstructured, string name, string product,
+        string ownerName, string[]? ownerAddressUnstructured, string name, string product,
         CashAccountType? cashAccountType, string? details, string? linkedAccounts, string? msisdn,
         IsoBankAccountStatus? status, BankAccountUsage? usage, string? maskedPan)
     {

--- a/src/RobinTTY.NordigenApiClient/Models/Responses/BankAccountDetails.cs
+++ b/src/RobinTTY.NordigenApiClient/Models/Responses/BankAccountDetails.cs
@@ -56,7 +56,7 @@ public class BankAccountDetails
     /// Address of the legal account owner.
     /// </summary>
     [JsonPropertyName("ownerAddressUnstructured")]
-    public string[]? OwnerAddressUnstructured { get; }
+    public List<string>? OwnerAddressUnstructured { get; }
 
     /// <summary>
     /// Name of the account, as assigned by the bank, in agreement with the account owner in


### PR DESCRIPTION
I've received this for polish Pekao bank and got serialisation error:

/api/v2/accounts/{id}/details/
```json
{
	"account": {
		"resourceId": "PL####################",
		"iban": "PL####################",
		"currency": "PLN",
		"ownerName": "#############",
		"product": "Rachunek oszczędnościowo – rozliczeniowy",
		"ownerAddressUnstructured": [
			"ZŁOTA 48-54 HOTEL MERCURE POKÓJ ###",
			"00-120 WARSZAWA",
			"POLSKA"
		]
	}
}
```

as we can see here, **ownerAddressUnstructured** is array of strings not just string. Official swagger for AccountDetailSchema also suggest that it's array: https://developer.gocardless.com/bank-account-data/endpoints